### PR TITLE
Fix #22: Remove repeated `value` property

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../paper-behaviors/paper-inky-focus-behavior.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
+<link rel="import" href="../iron-range-behavior/iron-range-behavior.html">
 <link rel="import" href="../iron-form-element-behavior/iron-form-element-behavior.html">
 
 <!--
@@ -163,13 +164,14 @@ To change the slider disabled secondary progress bar color:
     is: 'paper-slider',
 
     behaviors: [
-      Polymer.IronRangeBehavior,
       Polymer.IronA11yKeysBehavior,
+      Polymer.PaperInkyFocusBehavior,
       Polymer.IronFormElementBehavior,
-      Polymer.PaperInkyFocusBehavior
+      Polymer.IronRangeBehavior
     ],
 
     properties: {
+
       /**
        * If true, the slider thumb snaps to tick marks evenly spaced based
        * on the `step` property value.
@@ -280,7 +282,6 @@ To change the slider disabled secondary progress bar color:
 
     ready: function() {
       // issue polymer/polymer#1305
-
       this.async(function() {
         this._updateKnob(this.value);
         this._updateInputValue();


### PR DESCRIPTION
This a follow up on https://github.com/PolymerElements/paper-slider/pull/23.  I thought about renaming `value` to `numericValue` in `IronRangeBehavior`, but this "fix" will be more expensive as it breaks the existing API and will also require changes to `paper-progress`. Not good.   However, I propose to remove  `Polymer.IronFormElementBehavior` and add the functionality needed for iron-form.

\cc @jklein24 
