### PR TITLE
add custom property for bar color

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,51 +19,15 @@ Use `min` and `max` to specify the slider range. Default is `0` to `100`. For ex
 
 ### Styling slider
 
-To change the slider progress bar color:
-```css
+```
 paper-slider {
+  --paper-slider-bar-color: #fff;
   --paper-slider-active-color: #0f9d58;
-}
-```
-
-To change the slider knob color:
-```css
-paper-slider {
   --paper-slider-knob-color: #0f9d58;
-}
-```
-
-To change the slider pin color:
-```css
-paper-slider {
   --paper-slider-pin-color: #0f9d58;
-}
-```
-
-To change the slider pin's font color:
-```css
-paper-slider {
-  --paper-slider-pin-font-color: #0f9d58;
-}
-```
-
-To change the slider secondary progress bar color:
-```css
-paper-slider {
+  --paper-slider-font-color: #0f9d58;
   --paper-slider-secondary-color: #0f9d58;
-}
-```
-
-To change the slider disabled active color:
-```css
-paper-slider {
   --paper-slider-disabled-active-color: #ccc;
-}
-```
-
-To change the slider disabled secondary progress bar color:
-```css
-paper-slider {
   --paper-slider-disabled-secondary-color: #ccc;
 }
 ```

--- a/paper-slider.css
+++ b/paper-slider.css
@@ -83,6 +83,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   width: 100%;
   padding: 8px 0;
   margin: -8px 0;
+  background-color: var(--paper-slider-bar-color, transparent);
 }
 
 .ring #sliderBar {

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -33,49 +33,21 @@ Example:
 
     <paper-slider min="10" max="200" value="110"></paper-slider>
 
-Styling slider:
+### Styling
 
-To change the slider progress bar color:
+The following custom properties and mixins are available for styling:
 
-    paper-slider {
-      --paper-slider-active-color: #0f9d58;
-    }
-
-To change the slider knob color:
-
-    paper-slider {
-      --paper-slider-knob-color: #0f9d58;
-    }
-
-To change the slider pin color:
-
-    paper-slider {
-      --paper-slider-pin-color: #0f9d58;
-    }
-
-To change the slider pin's font color:
-
-    paper-slider {
-      --paper-slider-pin-font-color: #0f9d58;
-    }
-
-To change the slider secondary progress bar color:
-
-    paper-slider {
-      --paper-slider-secondary-color: #0f9d58;
-    }
-
-To change the slider disabled active color:
-
-    paper-slider {
-      --paper-slider-disabled-active-color: #ccc;
-    }
-
-To change the slider disabled secondary progress bar color:
-
-    paper-slider {
-      --paper-slider-disabled-secondary-color: #ccc;
-    }
+Custom property | Description | Default
+----------------|-------------|----------
+`--paper-slider-bar-color` | The background color of the slider | `transparent`
+`--paper-slider-active-color` | The progress bar color | `--google-blue-700`
+`--paper-slider-secondary-color` | The secondary progress bar color | `--google-blue-300`
+`--paper-slider-knob-color` | The knob color | `--google-blue-700`
+`--paper-slider-disabled-knob-color` | The disabled knob color | `--google-grey-500`
+`--paper-slider-pin-color` | The pin color | `--google-blue-700`
+`--paper-slider-font-color` | The pin's text color | `#fff`
+`--paper-slider-disabled-active-color` | The disabled progress bar color | `--google-grey-500`
+`--paper-slider-disabled-secondary-color` | The disabled secondary progress bar color | `--google-grey-300`
 
 @group Paper Elements
 @element paper-slider


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/paper-slider/issues/25

Also cleaned up the docs:
- used the styling docs we use in other elements (`paper-input` etc.)
- cleaned up all the words from the `README`, since they were exactly the same as the property names and were not really adding anything
