### PR TITLE
move the events to the bottom of the file so the doc shows up correctly.

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -110,26 +110,6 @@ Custom property | Description | Default
 </dom-module>
 
 <script>
-  /**
-   * Fired when the slider's value changes.
-   *
-   * @event value-change
-   */
-
-  /**
-   * Fired when the slider's immediateValue changes.
-   *
-   * @event immediate-value-change
-   */
-
-  /**
-   * Fired when the slider's value changes due to user interaction.
-   *
-   * Changes to the slider's value due to changes in an underlying
-   * bound variable will not trigger this event.
-   *
-   * @event change
-   */
 
   Polymer({
     is: 'paper-slider',
@@ -484,5 +464,27 @@ Custom property | Description | Default
       }
       this.fire('change');
     }
-  })
+  });
+
+  /**
+   * Fired when the slider's value changes.
+   *
+   * @event value-change
+   */
+
+  /**
+   * Fired when the slider's immediateValue changes.
+   *
+   * @event immediate-value-change
+   */
+
+  /**
+   * Fired when the slider's value changes due to user interaction.
+   *
+   * Changes to the slider's value due to changes in an underlying
+   * bound variable will not trigger this event.
+   *
+   * @event change
+   */
+
 </script>


### PR DESCRIPTION
fixes #28 

After the fix:
![screen shot 2015-06-18 at 3 41 28 pm](https://cloud.githubusercontent.com/assets/116360/8243948/c277f170-15d0-11e5-9995-59c3b1c1af55.png)
