### PR TITLE
Fix knob when value is changed while dragging

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -544,7 +544,7 @@ Custom property | Description | Default
 
         this.$.sliderKnob.style.left = (this.ratio * 100) + '%';
         if (this.dragging) {
-          this._knobstartx = this.ratio * this._w || 0;
+          this._knobstartx = this.ratio * this._w;
           this.translate3d(0, 0, 0, this.$.sliderKnob);
         }
       },
@@ -571,7 +571,7 @@ Custom property | Description | Default
       _trackStart: function(event) {
         this._w = this.$.sliderBar.offsetWidth;
         this._x = this.ratio * this._w;
-        this._startx = this._x || 0;
+        this._startx = this._x;
         this._knobstartx = this._startx;
         this._minx = - this._startx;
         this._maxx = this._w - this._startx;

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -543,6 +543,10 @@ Custom property | Description | Default
         this._setRatio(this._calcRatio(this.immediateValue));
 
         this.$.sliderKnob.style.left = (this.ratio * 100) + '%';
+        if (this.dragging) {
+          this._knobstartx = this.ratio * this._w || 0;
+          this.translate3d(0, 0, 0, this.$.sliderKnob);
+        }
       },
 
       _calcKnobPosition: function(ratio) {
@@ -568,6 +572,7 @@ Custom property | Description | Default
         this._w = this.$.sliderBar.offsetWidth;
         this._x = this.ratio * this._w;
         this._startx = this._x || 0;
+        this._knobstartx = this._startx;
         this._minx = - this._startx;
         this._maxx = this._w - this._startx;
         this.$.sliderKnob.classList.add('dragging');
@@ -586,7 +591,7 @@ Custom property | Description | Default
         this._setImmediateValue(immediateValue);
 
         // update knob's position
-        var translateX = ((this._calcRatio(immediateValue) * this._w) - this._startx);
+        var translateX = ((this._calcRatio(this.immediateValue) * this._w) - this._knobstartx);
         this.translate3d(translateX + 'px', 0, 0, this.$.sliderKnob);
       },
 


### PR DESCRIPTION
When `value` (or `min`, `max`, `snaps`, `step`) is changed while dragging, the knob position was wrong.

This is fixed by resetting `translate3d` and the start value it's calculated from. Also, `immediateValue` may be changed in setter (change listener), so it should be reread from `this`.
