### PR TITLE
Issue #46: Add style variables when at position '0'

### DIFF
--- a/paper-slider.css
+++ b/paper-slider.css
@@ -168,8 +168,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 .ring > #sliderKnob > #sliderKnobInner {
-  background-color: transparent;
-  border: 2px solid #c8c8c8;
+  background-color: var(--paper-slider-knob-start-color, transparent);
+  border: 2px solid var(--paper-slider-knob-start-border-color, #c8c8c8);
 }
 
 #sliderKnobInner::before {
@@ -197,7 +197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 }
 
 .pin.ring > #sliderKnob > #sliderKnobInner::before {
-  background-color: #c8c8c8;
+  background-color: var(--paper-slider-pin-start-color, #c8c8c8);
 }
 
 .pin.expand > #sliderKnob > #sliderKnobInner::before {

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -49,6 +49,9 @@ Custom property | Description | Default
 `--paper-slider-font-color` | The pin's text color | `#fff`
 `--paper-slider-disabled-active-color` | The disabled progress bar color | `--google-grey-500`
 `--paper-slider-disabled-secondary-color` | The disabled secondary progress bar color | `--google-grey-300`
+`--paper-slider-knob-start-color` | The fill color of the knob at the far left | `transparent`
+`--paper-slider-knob-start-border-color` | The border color of the knob at the far left | `#c8c8c8`
+`--paper-slider-pin-start-color` | The color of the pin at the far left | `#c8c8c8`
 
 @group Paper Elements
 @element paper-slider


### PR DESCRIPTION
Added new variables to style the color of the pin and knob when the slider is at position 'zero' or, the far left.

--paper-slider-knob-start-color
--paper-slider-knob-start-border-color
--paper-slider-pin-start-color
