### PR TITLE
Fix invalid array length error

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -426,7 +426,7 @@ Custom property | Description | Default
 
     _maxMarkersChanged: function(maxMarkers) {
       var l = (this.max - this.min) / this.step;
-      if (!this.snaps && l > maxMarkers) {
+      if (!this.snaps && l && l > maxMarkers) {
         this._setMarkers([]);
       } else {
         this._setMarkers(new Array(l));


### PR DESCRIPTION
This throws an invalid array length error when a slider is created dynamically and not immediately inserted into the dom. In this instance l can evaluate to NaN.
