### PR TITLE
Added --paper-slider-marker-color variable

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -164,7 +164,7 @@ Custom property | Description | Default
         width: 2px;
         height: 2px;
         border-radius: 50%;
-        background-color: black;
+        background-color: var(--paper-slider-marker-color, black);
       }
 
       #sliderKnob {


### PR DESCRIPTION
According to the material design mockups, the marker color isn't always black (eg, with a dark theme).
