### PR TITLE
markers array should update when dependent values change

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -428,9 +428,7 @@ Custom property | Description | Default
        */
       maxMarkers: {
         type: Number,
-        value: 0,
-        notify: true,
-        observer: '_maxMarkersChanged'
+        value: null
       },
 
       /**
@@ -467,7 +465,8 @@ Custom property | Description | Default
     observers: [
       '_updateKnob(value, min, max, snaps, step)',
       '_valueChanged(value)',
-      '_immediateValueChanged(immediateValue)'
+      '_immediateValueChanged(immediateValue)',
+      '_updateMarkers(min, max, snaps, step, maxMarkers)'
     ],
 
     hostAttributes: {
@@ -645,13 +644,13 @@ Custom property | Description | Default
       }
     },
 
-    _maxMarkersChanged: function(maxMarkers) {
+    _updateMarkers: function() {
       if (!this.snaps) {
         this._setMarkers([]);
       }
       var steps = Math.floor((this.max - this.min) / this.step);
-      if (steps > maxMarkers) {
-        steps = maxMarkers;
+      if (this.maxMarkers && steps > this.maxMarkers) {
+        steps = this.maxMarkers;
       }
       this._setMarkers(new Array(steps));
     },

--- a/test/basic.html
+++ b/test/basic.html
@@ -208,13 +208,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.down(slider.$.sliderBar, cursor);
       });
 
+      test('markers should show when snaps is true', function(done) {
+        slider.min = 0;
+        slider.max = 100;
+        slider.snaps = true;
+        slider.step = 4;
+        flush(function() {
+          assert.equal(slider.querySelectorAll('.slider-marker').length, 25);
+          done();
+        });
+      });
+
       test('max markers', function(done) {
         slider.min = 0;
         slider.max = 100;
-        slider.snap = true;
+        slider.snaps = true;
         slider.step = 4;
         slider.maxMarkers = 10;
         flush(function() {
+          assert.equal(slider.querySelectorAll('.slider-marker').length, 10);
           assert.equal(slider.markers.length, 10);
           done();
         });


### PR DESCRIPTION
There was another problem introduced by my fix for #82 (markers didn't show when `maxMarkers` was `0`). While fixing that, I realized that the code for updating the markers should be pulled out into an observer that reacts to all the properties that affect the number of markers (`min`, `max`, `step`, `snaps`, & `maxMarkers`). This PR fixes that.`
