### PR TITLE
moved slider positioning into RAF to eliminate bad jitter

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -585,7 +585,10 @@ Custom property | Description | Default
 
       // update knob's position
       var translateX = ((this._calcRatio(immediateValue) * this._w) - this._startx);
-      this.translate3d(translateX + 'px', 0, 0, this.$.sliderKnob);
+
+      window.requestAnimationFrame(function() {
+        this.translate3d(translateX + 'px', 0, 0, this.$.sliderKnob);
+      }.bind(this));
     },
 
     _trackEnd: function() {


### PR DESCRIPTION
When using `snaps`, there's a bad jitter when moving the slider at certain speeds. Putting the `translate3d` call inside a requestAnimationFrame seems to fix this.
