### PR TITLE
stop bringing in the paper-styles kitchen sink

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
-    "web-component-tester": "*",
+    "web-component-tester": "polymer/web-component-tester#^3.4.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -18,13 +18,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../paper-styles/demo-pages.html">
+  <link rel="import" href="../../paper-styles/color.html">
   <link rel="import" href="../paper-slider.html">
 
   <style is="custom-style">
     body {
       padding: 40px;
     }
-    
+
     paper-slider {
       width: 100%;
     }
@@ -63,7 +64,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body unresolved>
-  <div class="vertical center-justified layout">
+  <div class="vertical-section-container">
     <h4>Default</h4>
     <div class="vertical-section">
       <div>Oxygen</div>
@@ -80,19 +81,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <h4>Editable</h4>
     <div class="vertical-section">
-      <div class="center horizontal layout">
+      <div>
         <div>R</div>
         <paper-slider class="red" value="23" max="255" editable></paper-slider>
       </div>
-      <div class="center horizontal layout">
+      <div>
         <div>G</div>
         <paper-slider class="green" value="183" max="255" editable></paper-slider>
       </div>
-      <div class="center horizontal layout">
+      <div>
         <div>B</div>
         <paper-slider class="blue" value="211" max="255" editable></paper-slider>
       </div>
-      <div class="center horizontal layout">
+      <div>
       <div>&alpha;</div>
       <paper-slider max="1.0" step="0.01" editable></paper-slider>
       </div>

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -151,8 +151,12 @@ Custom property | Description | Default
         right: -1px;
         box-sizing: border-box;
         pointer-events: none;
+        @apply(--layout-horizontal);
       }
 
+      .slider-marker {
+        @apply(--layout-flex);
+      }
       .slider-markers::after,
       .slider-marker::after {
         content: "";
@@ -327,9 +331,9 @@ Custom property | Description | Default
       </div>
 
       <template is="dom-if" if="[[snaps]]">
-        <div class="slider-markers horizontal layout">
+        <div class="slider-markers">
           <template is="dom-repeat" items="[[markers]]">
-            <div class="slider-marker flex"></div>
+            <div class="slider-marker"></div>
           </template>
         </div>
       </template>

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -16,11 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../paper-slider.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
 </head>
 <body>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -16,11 +16,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../paper-slider.html">
-  <link rel="import" href="../../test-fixture/test-fixture.html">
 </head>
 <body>
 


### PR DESCRIPTION
Fixes the generic usage of `paper-styles.html` and `/deep/` classes and uses the specific imports instead. Also updates the test to the new `wct#^3.4.0` way

/cc @blasten 
