### PR TITLE
Update to Polymer 1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
   },
   "ignore": [],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#^1.1.0",
     "paper-input": "PolymerElements/paper-input#^1.0.0",
     "paper-progress": "PolymerElements/paper-progress#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",


### PR DESCRIPTION
Update to Polymer 1.1, because the style tag is inside de dom-module.
More info about the Polymer 1.1 style recommendations: https://blog.polymer-project.org/announcements/2015/08/13/1.1-release/
