### PR TITLE
Make slider focused after click on the bar

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -633,6 +633,9 @@ Custom property | Description | Default
 
         // cancel selection
         event.preventDefault();
+
+        // set the focus manually because we will called prevent default
+        this.focus();
       },
 
       _knobTransitionEnd: function(event) {

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -65,6 +65,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isAbove(ripple.offsetWidth, 0);
       });
 
+      test('slider has focus after click event on bar"', function() {
+        MockInteractions.down(slider.$.sliderBar);
+        assert.isTrue(slider.focused);
+      });
+
       a11ySuite('trivialSlider');
 
     });


### PR DESCRIPTION
Fixes #112 

Directly set the focus after clicking on the slider bar by calling `this.focus()`
