### PR TITLE
Triger markers[] update when steps, min, or max changes

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -458,7 +458,7 @@ Custom property | Description | Default
         '_updateKnob(value, min, max, snaps, step)',
         '_valueChanged(value)',
         '_immediateValueChanged(immediateValue)',
-        '_maxMarkersChanged(maxMarkers, min, max, snaps)
+        '_updateMarkers(maxMarkers, min, max, snaps)'
       ],
 
       hostAttributes: {
@@ -644,7 +644,7 @@ Custom property | Description | Default
         }
       },
 
-      _maxMarkersChanged: function(maxMarkers, min, max, snaps) {
+      _updateMarkers: function(maxMarkers, min, max, snaps) {
         if (!snaps) {
           this._setMarkers([]);
         }

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -420,8 +420,7 @@ Custom property | Description | Default
         maxMarkers: {
           type: Number,
           value: 0,
-          notify: true,
-          observer: '_maxMarkersChanged'
+          notify: true
         },
 
         /**
@@ -458,7 +457,8 @@ Custom property | Description | Default
       observers: [
         '_updateKnob(value, min, max, snaps, step)',
         '_valueChanged(value)',
-        '_immediateValueChanged(immediateValue)'
+        '_immediateValueChanged(immediateValue)',
+        '_maxMarkersChanged(maxMarkers, min, max, snaps)
       ],
 
       hostAttributes: {
@@ -644,11 +644,11 @@ Custom property | Description | Default
         }
       },
 
-      _maxMarkersChanged: function(maxMarkers) {
-        if (!this.snaps) {
+      _maxMarkersChanged: function(maxMarkers, min, max, snaps) {
+        if (!snaps) {
           this._setMarkers([]);
         }
-        var steps = Math.round((this.max - this.min) / this.step);
+        var steps = Math.round((max - min) / this.step);
         if (steps > maxMarkers) {
           steps = maxMarkers;
         }


### PR DESCRIPTION
Currently <paper-slider snaps max-markers="10"> does not work reliably because the max-markers change event may trigger before snaps (and will not get triggered again when snaps changes).

Changing 'steps' could have similar issues, but that isn't even declared as an attribute currently.
