### PR TITLE
Configurable knob size

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ The following custom properties and mixins are available for styling:
 | `--paper-slider-pin-start-color` | The color of the pin at the far left | `--paper-grey-400` |
 | `--paper-slider-height` | Height of the progress bar | `2px` |
 | `--paper-slider-input` | Mixin applied to the input in editable mode | `{}` |
+| `--paper-slider-knob-size` | Size of the knob | `calc(10px + var(--paper-slider-height))` |

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -58,6 +58,7 @@ Custom property | Description | Default
 `--paper-slider-pin-start-color` | The color of the pin at the far left | `--paper-grey-400`
 `--paper-slider-height` | Height of the progress bar | `2px`
 `--paper-slider-input` | Mixin applied to the input in editable mode | `{}`
+`--paper-slider-knob-size` | Size of the knob | `calc(10px + var(--paper-slider-height))`
 
 @group Paper Elements
 @element paper-slider
@@ -84,6 +85,7 @@ Custom property | Description | Default
         --paper-progress-disabled-active-color: var(--paper-slider-disabled-active-color, --paper-grey-400);
         --paper-progress-disabled-secondary-color: var(--paper-slider-disabled-secondary-color, --paper-grey-400);
         --calculated-paper-slider-height: var(--paper-slider-height, 2px);
+        --calculated-paper-slider-knob-size: var(--paper-slider-knob-size, 10px);
       }
 
       /* focus shows the ripple */
@@ -94,9 +96,9 @@ Custom property | Description | Default
       #sliderContainer {
         position: relative;
         width: 100%;
-        height: calc(30px + var(--calculated-paper-slider-height));
-        margin-left: calc(15px + var(--calculated-paper-slider-height)/2);
-        margin-right: calc(15px + var(--calculated-paper-slider-height)/2);
+        height: calc(20px + var(--calculated-paper-slider-knob-size) + var(--calculated-paper-slider-height));
+        margin-left: calc(10px + var(--calculated-paper-slider-knob-size)/2 + var(--calculated-paper-slider-height)/2);
+        margin-right: calc(10px + var(--calculated-paper-slider-knob-size)/2 + var(--calculated-paper-slider-height)/2);
       }
 
       #sliderContainer:focus {
@@ -118,7 +120,7 @@ Custom property | Description | Default
       }
 
       .ring > .bar-container {
-        left: calc(5px + var(--calculated-paper-slider-height)/2);
+        left: calc(var(--calculated-paper-slider-knob-size)/2 + var(--calculated-paper-slider-height));
         transition: left 0.18s ease;
       }
 
@@ -131,7 +133,8 @@ Custom property | Description | Default
       }
 
       #sliderBar {
-        padding: 15px 0;
+        padding: 0;
+        padding-top: calc(var(--calculated-paper-slider-knob-size)/2 + 10px );
         width: 100%;
         background-color: var(--paper-slider-bar-color, transparent);
         --paper-progress-container-color: var(--paper-slider-container-color, --paper-grey-400);
@@ -167,9 +170,9 @@ Custom property | Description | Default
         position: absolute;
         left: 0;
         top: 0;
-        margin-left: calc(-15px - var(--calculated-paper-slider-height)/2);
-        width: calc(30px + var(--calculated-paper-slider-height));
-        height: calc(30px + var(--calculated-paper-slider-height));
+        margin-left: calc(0px - 10px - var(--calculated-paper-slider-knob-size) / 2 - var(--calculated-paper-slider-height));
+        width: calc(var(--calculated-paper-slider-knob-size) + var(--calculated-paper-slider-height) + 20px);
+        height: calc(var(--calculated-paper-slider-knob-size) + var(--calculated-paper-slider-height) + 20px);
       }
 
       .transiting > .slider-knob {


### PR DESCRIPTION
Fix #154 - Make knob size configurable
## Fix #154 - Make knob size configurable
### Description

I use `paper-slider` in metro-like tiles, and in order to make them look good, I give them a high `--paper-slider-height`.  

Currently the knob size is fixed to 10px+  `--paper-slider-height` (and it's inside a knob container `div` of 30px + `--paper-slider-height` ). With big values of `--paper-slider-height` (let's say 10px), the knob looks too small.

I thought that a `--paper-slider-knob-size` would be a worthy and fitting addition to the CSS custom properties available for `paper-slider`.
### Actual look

High `--paper-slider-height`  without  `--paper-slider-knob-size`:

![paper-slider-before](https://cloud.githubusercontent.com/assets/726476/19349264/6329e62a-9152-11e6-92f5-e5ec1c3a870c.png)
### Desired look

High `--paper-slider-height`  with  `--paper-slider-knob-size`, using the modified version on [my fork](https://github.com/LostInBrittany/paper-slider):

![paper-slider-after](https://cloud.githubusercontent.com/assets/726476/19349263/63288ea6-9152-11e6-94d8-77c686cf080c.png)
### Live Demo

Example: http://jsbin.com/pilogib/4/edit?html,output
### Tested on
- [x ] Chrome
- [x] Firefox
- [x] Safari 9
- [ ] Safari 8
- [ ] Safari 7
- [x] Edge
- [x] IE 11
- [ ] IE 10
