### PR TITLE
Added property for pin label.

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -334,7 +334,7 @@ Custom property | Description | Default
         on-up="_resetKnob"
         on-track="_onTrack"
         on-transitionend="_knobTransitionEnd">
-          <div class="slider-knob-inner" value$="[[immediateValue]]"></div>
+          <div class="slider-knob-inner" value$="[[_getPinLabel(pinLabel, immediateValue)]]"></div>
       </div>
     </div>
 
@@ -386,6 +386,16 @@ Custom property | Description | Default
           type: Boolean,
           value: false,
           notify: true
+        },
+
+        /**
+         * If set, a this text will be used in the pin instead of just the numeric
+         * number. Use if you need to format the label in any way.
+         */
+        pinLabel: {
+          type: String,
+          value: "",
+          notify: false
         },
 
         /**
@@ -702,6 +712,10 @@ Custom property | Description | Default
 
       _inputKeyDown: function(event) {
         event.stopPropagation();
+      },
+
+      _getPinLabel: function(pinLabel, value) {
+        return pinLabel ? pinLabel : value;
       },
 
       // create the element ripple inside the `sliderKnob`


### PR DESCRIPTION
Solves https://github.com/PolymerElements/paper-slider/issues/133 although with a little more customization than suggested there.

I've added an optional pinLabel property that if set, will be used for the pin label instead of just the immediateValue. That way, you can create your own text with bindings, like so:

`immediate-value="{{durationSliderValue}}" pin-label="[[_readableDuration(durationSliderValue)]]"`

If not set, the value will be used as normal, so no breaking changes.