### PR TITLE
Make ratio property 0-100 (consistent with iron-range-behavior)

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -504,7 +504,7 @@ Custom property | Description | Default
         this.setAttribute('aria-valuemax', max);
         this.setAttribute('aria-valuenow', value);
 
-        this._positionKnob(this._calcRatio(value));
+        this._positionKnob(this._calcRatio(value) * 100);
       },
 
       _valueChanged: function() {
@@ -534,17 +534,17 @@ Custom property | Description | Default
 
       _positionKnob: function(ratio) {
         this._setImmediateValue(this._calcStep(this._calcKnobPosition(ratio)));
-        this._setRatio(this._calcRatio(this.immediateValue));
+        this._setRatio(this._calcRatio(this.immediateValue) * 100);
 
-        this.$.sliderKnob.style.left = (this.ratio * 100) + '%';
+        this.$.sliderKnob.style.left = this.ratio + '%';
         if (this.dragging) {
-          this._knobstartx = this.ratio * this._w;
+          this._knobstartx = (this.ratio * this._w) / 100;
           this.translate3d(0, 0, 0, this.$.sliderKnob);
         }
       },
 
       _calcKnobPosition: function(ratio) {
-        return (this.max - this.min) * ratio + this.min;
+        return (this.max - this.min) * ratio / 100 + this.min;
       },
 
       _onTrack: function(event) {
@@ -565,7 +565,7 @@ Custom property | Description | Default
       _trackStart: function(event) {
         this._setTransiting(false);
         this._w = this.$.sliderBar.offsetWidth;
-        this._x = this.ratio * this._w;
+        this._x = this.ratio * this._w / 100;
         this._startx = this._x;
         this._knobstartx = this._startx;
         this._minx = - this._startx;
@@ -584,7 +584,7 @@ Custom property | Description | Default
             this._maxx, Math.max(this._minx, event.detail.dx * direction));
         this._x = this._startx + dx;
 
-        var immediateValue = this._calcStep(this._calcKnobPosition(this._x / this._w));
+        var immediateValue = this._calcStep(this._calcKnobPosition(this._x / this._w * 100));
         this._setImmediateValue(immediateValue);
 
         // update knob's position
@@ -618,9 +618,9 @@ Custom property | Description | Default
       _bardown: function(event) {
         this._w = this.$.sliderBar.offsetWidth;
         var rect = this.$.sliderBar.getBoundingClientRect();
-        var ratio = (event.detail.x - rect.left) / this._w;
+        var ratio = (event.detail.x - rect.left) / this._w * 100;
         if (this._isRTL) {
-          ratio = 1 - ratio;
+          ratio = 100 - ratio;
         }
         var prevRatio = this.ratio;
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -69,7 +69,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.max = 10;
         slider.value = 5;
         flush(function() {
-          assert.equal(slider.ratio, 0.5);
+          assert.equal(slider.ratio, 50);
           done();
         });
       });


### PR DESCRIPTION
Fixes #177 

Before this patch, paper-slider’s `ratio` property ranges 0-1.0 (https://github.com/PolymerElements/paper-slider/blob/master/paper-slider.html#L537). However, iron-range-behavior and paper-progress uses `ratio` between 0-100 (https://github.com/PolymerElements/iron-range-behavior/blob/master/iron-range-behavior.html#L117). The timing changes with Polymer 2.0 surfaces this issue, since iron-range-behavior’s `_update` method sets ratio between 0-100.

This patch fixes this inconsistency by making paper-slider use the 0-100 range as well. However, it is technically a breaking change since the semantics of `ratio` is now different. There are alternative fixes (e.g. override the `_update` method in paper-slider), but that would mean this inconsistency would still exist, so I’m proposing this fix instead.