### PR TITLE
Add property for ignoring touch dragging on the slider bar

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -344,7 +344,7 @@ Custom property | Description | Default
           step="[[step]]"
           value="[[immediateValue]]"
           secondary-progress="[[secondaryProgress]]"
-          on-down="_bardown"
+          on-mousedown="_bardown"
           on-up="_resetKnob"
           on-track="_onTrack">
         </paper-progress>

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -667,13 +667,11 @@ Custom property | Description | Default
         var prevRatio = this.ratio;
 
         this._setTransiting(true);
-
         this._positionKnob(ratio);
 
         // if the ratio doesn't change, sliderKnob's animation won't start
         // and `_knobTransitionEnd` won't be called
         // Therefore, we need to manually update the `transiting` state
-
         if (prevRatio === this.ratio) {
           this._setTransiting(false);
         }
@@ -687,7 +685,6 @@ Custom property | Description | Default
 
         // set the focus manually because we will called prevent default
         this.focus();
-
       },
 
       _bardown: function(event) {

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -92,7 +92,7 @@ Custom property | Description | Default
         outline: none;
       }
 
-      /** 
+      /**
        * NOTE(keanulee): Though :host-context is not universally supported, some pages
        * still rely on paper-slider being flipped when dir="rtl" is set on body. For full
        * compatability, dir="rtl" must be explicitly set on paper-slider.
@@ -102,7 +102,7 @@ Custom property | Description | Default
         transform: scaleX(-1);
       }
 
-      /** 
+      /**
        * NOTE(keanulee): This is separate from the rule above because :host-context may
        * not be recognized.
        */
@@ -111,7 +111,7 @@ Custom property | Description | Default
         transform: scaleX(-1);
       }
 
-      /** 
+      /**
        * NOTE(keanulee): Needed to override the :host-context rule (where supported)
        * to support LTR sliders in RTL pages.
        */
@@ -344,10 +344,9 @@ Custom property | Description | Default
           step="[[step]]"
           value="[[immediateValue]]"
           secondary-progress="[[secondaryProgress]]"
-          on-mousedown="_bardown"
-          on-tap="_bardown"
+          on-click="_barclick"
           on-up="_resetKnob"
-          on-track="_onTrack">
+          >
         </paper-progress>
       </div>
 
@@ -642,10 +641,10 @@ Custom property | Description | Default
         this.focus();
       },
 
-      _bardown: function(event) {
+      _barclick: function(event) {
         this._w = this.$.sliderBar.offsetWidth;
         var rect = this.$.sliderBar.getBoundingClientRect();
-        var ratio = (event.detail.x - rect.left) / this._w * 100;
+        var ratio = (event.x - rect.left) / this._w * 100;
         if (this._isRTL) {
           ratio = 100 - ratio;
         }
@@ -654,8 +653,6 @@ Custom property | Description | Default
         this._setTransiting(true);
 
         this._positionKnob(ratio);
-
-        this.debounce('expandKnob', this._expandKnob, 60);
 
         // if the ratio doesn't change, sliderKnob's animation won't start
         // and `_knobTransitionEnd` won't be called

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -345,6 +345,7 @@ Custom property | Description | Default
           value="[[immediateValue]]"
           secondary-progress="[[secondaryProgress]]"
           on-mousedown="_bardown"
+          on-tap="_bardown"
           on-up="_resetKnob"
           on-track="_onTrack">
         </paper-progress>

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -344,9 +344,10 @@ Custom property | Description | Default
           step="[[step]]"
           value="[[immediateValue]]"
           secondary-progress="[[secondaryProgress]]"
-          on-click="_barclick"
+          on-down="_bardown"
           on-up="_resetKnob"
-          >
+          on-track="_bartrack"
+          on-tap="_barclick">
         </paper-progress>
       </div>
 
@@ -463,6 +464,15 @@ Custom property | Description | Default
           type: Boolean,
           value: false,
           readOnly: true
+        },
+
+        /**
+         * If true, a touchmove on the slider bar doesn't drag the slider thunb.
+         * Tapping on the slider bar still updates the slider's position
+         */
+        ignoreBarTouch: {
+          type: Boolean,
+          value: false
         },
 
         /**
@@ -641,10 +651,16 @@ Custom property | Description | Default
         this.focus();
       },
 
+      _bartrack: function(event) {
+        if (this._allowBarEvent(event)) {
+          this._onTrack(event);
+        }
+      },
+
       _barclick: function(event) {
         this._w = this.$.sliderBar.offsetWidth;
         var rect = this.$.sliderBar.getBoundingClientRect();
-        var ratio = (event.x - rect.left) / this._w * 100;
+        var ratio = (event.detail.x - rect.left) / this._w * 100;
         if (this._isRTL) {
           ratio = 100 - ratio;
         }
@@ -671,6 +687,14 @@ Custom property | Description | Default
 
         // set the focus manually because we will called prevent default
         this.focus();
+
+      },
+
+      _bardown: function(event) {
+        if (this._allowBarEvent(event)) {
+          this.debounce('expandKnob', this._expandKnob, 60);
+          this._barclick(event);
+        }
       },
 
       _knobTransitionEnd: function(event) {
@@ -711,6 +735,10 @@ Custom property | Description | Default
           transiting: this.transiting,
           editable: this.editable
         });
+      },
+
+      _allowBarEvent: function(event) {
+        return (!this.ignoreBarTouch || (event.detail.sourceEvent instanceof MouseEvent))
       },
 
       get _isRTL() {

--- a/test/basic.html
+++ b/test/basic.html
@@ -158,7 +158,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      test('snap to the correct value on tapping', function(done) {
+      test('snap to the correct value on tapping/clicking', function(done) {
         var cursor = MockInteractions.topLeftOfNode(slider.$.sliderBar);
         cursor.x += slider.$.sliderBar.getBoundingClientRect().width * 0.9;
 
@@ -167,7 +167,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 0;
 
-        MockInteractions.tap(slider.$.sliderBar, cursor);
+        MockInteractions.click(slider.$.sliderBar, cursor);
 
         flush(function() {
           assert.equal(slider.value, slider.max);
@@ -221,7 +221,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         slider.min = 0;
         slider.max = 100;
-        MockInteractions.tap(slider.$.sliderBar, cursor);
+        MockInteractions.click(slider.$.sliderBar, cursor);
       });
 
       test('max markers', function(done) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -167,7 +167,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 0;
 
-        MockInteractions.down(slider.$.sliderBar, cursor);
+        MockInteractions.tap(slider.$.sliderBar, cursor);
 
         flush(function() {
           assert.equal(slider.value, slider.max);
@@ -183,7 +183,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 0;
 
-        MockInteractions.track(slider.$.sliderBar, sliderWidth * 0.9, 0);
+        MockInteractions.track(slider.$.sliderKnob, sliderWidth * 0.9, 0);
 
         flush(function() {
           assert.equal(slider.value, slider.max);
@@ -221,7 +221,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         slider.min = 0;
         slider.max = 100;
-        MockInteractions.down(slider.$.sliderBar, cursor);
+        MockInteractions.tap(slider.$.sliderBar, cursor);
       });
 
       test('max markers', function(done) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -167,7 +167,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 0;
 
-        MockInteractions.click(slider.$.sliderBar, cursor);
+        MockInteractions.down(slider.$.sliderBar, cursor);
+        MockInteractions.up(slider.$.sliderBar, cursor);
 
         flush(function() {
           assert.equal(slider.value, slider.max);
@@ -221,7 +222,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         slider.min = 0;
         slider.max = 100;
-        MockInteractions.click(slider.$.sliderBar, cursor);
+        MockInteractions.down(slider.$.sliderBar, cursor);
+        MockInteractions.up(slider.$.sliderBar, cursor);
       });
 
       test('max markers', function(done) {

--- a/test/rtl.html
+++ b/test/rtl.html
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 2;
 
-        MockInteractions.down(slider.$.sliderBar, cursor);
+        MockInteractions.tap(slider.$.sliderBar, cursor);
 
         flush(function() {
           assert.equal(slider.value, slider.min);
@@ -60,7 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 2;
 
-        MockInteractions.track(slider.$.sliderBar, sliderWidth * 0.9, 0);
+        MockInteractions.track(slider.$.sliderKnob, sliderWidth * 0.9, 0);
 
         flush(function() {
           assert.equal(slider.value, slider.min);

--- a/test/rtl.html
+++ b/test/rtl.html
@@ -45,7 +45,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 2;
 
-        MockInteractions.click(slider.$.sliderBar, cursor);
+        MockInteractions.down(slider.$.sliderBar, cursor);
+        MockInteractions.up(slider.$.sliderBar, cursor);
 
         flush(function() {
           assert.equal(slider.value, slider.min);

--- a/test/rtl.html
+++ b/test/rtl.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider = fixture('rtlProgress');
       });
 
-      test('snap to the correct value on tapping', function(done) {
+      test('snap to the correct value on tapping/clicking', function(done) {
         var cursor = MockInteractions.topLeftOfNode(slider.$.sliderBar);
         cursor.x += slider.$.sliderBar.getBoundingClientRect().width * 0.9;
 
@@ -45,7 +45,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         slider.step = 1;
         slider.value = 2;
 
-        MockInteractions.tap(slider.$.sliderBar, cursor);
+        MockInteractions.click(slider.$.sliderBar, cursor);
 
         flush(function() {
           assert.equal(slider.value, slider.min);


### PR DESCRIPTION
Only a tap and a mousedown on the bar should alter the knob-position.
Fixes https://github.com/PolymerElements/paper-slider/issues/178