### PR TITLE
fix scrolling with ignoreBarTouch on android

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -519,6 +519,12 @@ Custom property | Description | Default
         'up pageup end': '_incrementKey'
       },
 
+      ready: function() {
+        if(this.ignoreBarTouch) {
+          Polymer.Gestures.setTouchAction(this.$.sliderBar, 'auto');
+        }
+      },
+      
       /**
        * Increases value by `step` but not above `max`.
        * @method increment


### PR DESCRIPTION
Fixes #210 by setting `touch-action: auto` (the default) when ignoreBarTouch is set to `true`.

Adding the `track` eventlistener will set `touch-action` style property to `none`.
This obviously prevents scrolling, which kind of defeats the whole point of setting ignoreBarTouch to `true`

Because this element is still in the old style, I wonder if I actually picked the right lifecycle method to implement this in. Were not doing anything fancy, basically just removing an inline element style.

P.S. I'm sorry I missed this on my first implementation of 'ignoreBarTouch'