### PR TITLE
fix --paper-slider-height marker offset

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -366,9 +366,7 @@ Custom property | Description | Default
         on-up="_resetKnob"
         on-track="_onTrack"
         on-transitionend="_knobTransitionEnd">
-          <div class="slider-knob-inner" value$="[[immediateValue]]">
-            <slot name="knob" slot="knob"></slot>
-          </div>
+          <div class="slider-knob-inner" value$="[[immediateValue]]"></div>
       </div>
     </div>
 

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -366,7 +366,9 @@ Custom property | Description | Default
         on-up="_resetKnob"
         on-track="_onTrack"
         on-transitionend="_knobTransitionEnd">
-          <div class="slider-knob-inner" value$="[[immediateValue]]"></div>
+          <div class="slider-knob-inner" value$="[[immediateValue]]">
+            <slot name="knob" slot="knob"></slot>
+          </div>
       </div>
     </div>
 

--- a/paper-slider.html
+++ b/paper-slider.html
@@ -169,7 +169,8 @@ Custom property | Description | Default
 
       .slider-markers {
         position: absolute;
-        top: calc(14px + var(--paper-slider-height,2px)/2);
+        /* slider-knob is 30px + the slider-height so that the markers should start at a offset of 15px*/
+        top: 15px;
         height: var(--calculated-paper-slider-height);
         left: 0;
         right: -1px;


### PR DESCRIPTION
### Description
When changing the height of a `paper-slider` via `--paper-slider-height` and enable markers, 
the markers are not properly positioned on the sliders `paper-progress`

### Expected outcome
The markers should be aligned with the `paper-progress`

![Expected outcome](https://user-images.githubusercontent.com/1645253/40546777-6f7b7318-6030-11e8-9d8b-9b5d1e91235f.png)

### Actual outcome
The have an offset, that pushes them off the `paper-progress`

![Actual outcome](https://user-images.githubusercontent.com/1645253/40546798-7a082394-6030-11e8-8267-554a9e585037.png)

### Live Demo
Demo: https://jsfiddle.net/j7wpzv9c/2/
Fix: https://jsfiddle.net/yu5bjy6g/

### Steps to reproduce

<!-- Example
1. Put a `paper-slider` element in the page and set `snaps`, `min`, `max`, `step` and  `value`.
2. Change set the `--paper-slider-height` variable to something bigger then 2px
3. Open the page in a web browser.
-->

### Browsers Affected
<!-- Check all that apply -->
- [x] Chrome
- [x] Firefox
- [x] Safari 11
- [ ] Safari 10
- [ ] Safari 8
- [ ] Safari 7
- [ ] Edge
- [ ] IE 11
- [ ] IE 10

This PR fixes the issue.