### PR TITLE
Fixed bug in RTL where the pin content was mirrored and unreadable

### DIFF
--- a/paper-slider.js
+++ b/paper-slider.js
@@ -254,6 +254,16 @@ const template = html`
       transform: scale(1) translate(0, -17px);
     }
 
+    :dir(rtl) .pin.expand > .slider-knob > .slider-knob-inner::after {
+      -webkit-transform: scale(1) translate(0, -17px) scaleX(-1);
+      transform: scale(1) translate(0, -17px) scaleX(-1);
+    }
+
+    :host([dir="rtl"]) .pin.expand > .slider-knob > .slider-knob-inner::after {
+      -webkit-transform: scale(1) translate(0, -17px) scaleX(-1);
+      transform: scale(1) translate(0, -17px) scaleX(-1);
+    }
+    
     /* paper-input */
     .slider-input {
       width: 50px;


### PR DESCRIPTION
Before fix (look at the pin):
<img width="375" alt="slider-pin-before" src="https://user-images.githubusercontent.com/37745463/51103892-06c87800-17ed-11e9-851a-e8c8243c4994.png">

After fix (ignore the number mismatch below - it's because of the screen cap)
<img width="374" alt="slider-pin-after" src="https://user-images.githubusercontent.com/37745463/51106734-47c48a80-17f5-11e9-8dd2-6e9ba3d90713.png">


